### PR TITLE
Fix #179: Avoid double wrapping with Collections.unmodifiableList()

### DIFF
--- a/api/client/src/main/java/javax/websocket/ClientEndpointConfig.java
+++ b/api/client/src/main/java/javax/websocket/ClientEndpointConfig.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/client/src/main/java/javax/websocket/ClientEndpointConfig.java
+++ b/api/client/src/main/java/javax/websocket/ClientEndpointConfig.java
@@ -152,10 +152,10 @@ public interface ClientEndpointConfig extends EndpointConfig {
         */
        public ClientEndpointConfig build() {
            return new DefaultClientEndpointConfig(
-               Collections.unmodifiableList(this.preferredSubprotocols),
-               Collections.unmodifiableList(this.extensions),
-               Collections.unmodifiableList(this.encoders),
-               Collections.unmodifiableList(this.decoders),
+               this.preferredSubprotocols,
+               this.extensions,
+               this.encoders,
+               this.decoders,
                this.clientEndpointConfigurator);
        }
 

--- a/api/server/src/main/java/javax/websocket/server/ServerEndpointConfig.java
+++ b/api/server/src/main/java/javax/websocket/server/ServerEndpointConfig.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/server/src/main/java/javax/websocket/server/ServerEndpointConfig.java
+++ b/api/server/src/main/java/javax/websocket/server/ServerEndpointConfig.java
@@ -278,10 +278,10 @@ public interface ServerEndpointConfig extends EndpointConfig {
             return new DefaultServerEndpointConfig(
                     this.endpointClass,
                     this.path,
-                    Collections.unmodifiableList(this.subprotocols),
-                    Collections.unmodifiableList(this.extensions),
-                    Collections.unmodifiableList(this.encoders),
-                    Collections.unmodifiableList(this.decoders),
+                    this.subprotocols,
+                    this.extensions,
+                    this.encoders,
+                    this.decoders,
                     this.serverEndpointConfigurator
                  );
         }


### PR DESCRIPTION
Fix #179 by removing wrapping in call to Default[Client|Server]EndpointConfig constructor