### PR TITLE
Fix #233 - Serializable classes should have a serialVersionUID

### DIFF
--- a/api/client/src/main/java/javax/websocket/DeploymentException.java
+++ b/api/client/src/main/java/javax/websocket/DeploymentException.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +24,8 @@ package javax.websocket;
  * @author dannycoward
  */
 public class DeploymentException extends Exception {
+
+    private static final long serialVersionUID = 7576860738144220015L;
 
     /**
      * Creates a deployment exception with the given reason for the deployment


### PR DESCRIPTION
I used a generated ID to retain compatibility with the already released class.