### PR TITLE
Update groupId as per

### DIFF
--- a/api/client/pom.xml
+++ b/api/client/pom.xml
@@ -21,7 +21,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>jakarta</groupId>
+        <groupId>jakarta.websocket</groupId>
         <artifactId>jakarta.websocket-all</artifactId>
         <version>1.1.1</version>
     </parent>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,7 +27,7 @@
         <version>1.0.1</version>
     </parent>
 
-    <groupId>jakarta</groupId>
+    <groupId>jakarta.websocket</groupId>
     <artifactId>jakarta.websocket-all</artifactId>
     <packaging>pom</packaging>
     <!--
@@ -215,7 +215,7 @@
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>spec-version-maven-plugin</artifactId>
-                    <version>1.2</version>
+                    <version>1.5</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -21,7 +21,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>jakarta</groupId>
+        <groupId>jakarta.websocket</groupId>
         <artifactId>jakarta.websocket-all</artifactId>
         <version>1.1.1</version>
     </parent>
@@ -43,6 +43,7 @@
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
                 <configuration>
+                    <specMode>jakarta</specMode>
                     <spec>
                         <nonFinal>false</nonFinal>
                         <jarType>api</jarType>
@@ -57,13 +58,7 @@
                     <execution>
                         <goals>
                             <goal>set-spec-properties</goal>
-                            <!--
-                                Disable the check as it currently because the
-                                groupId does not start with javax. See #266
-                            -->
-                            <!--
                             <goal>check-module</goal>
-                            -->
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
https://github.com/eclipse-ee4j/ee4j/wiki/New-Maven-Coordinates

Update spec plugin to 1.5 which is now able to validate jakarta
Maven co-ordinates

Signed-off-by: Mark Thomas <markt@apache.org>