### PR TITLE
Fix client Javadoc errors currently blocking the release

### DIFF
--- a/api/client/src/main/java/javax/websocket/ClientEndpoint.java
+++ b/api/client/src/main/java/javax/websocket/ClientEndpoint.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * The ClientEndpoint annotation a class level annotation is used to denote that a POJO is a web socket client and can
- * be deployed as such. Similar to {@link javax.websocket.server.ServerEndpoint}, POJOs that are annotated with this
+ * be deployed as such. Similar to {@code javax.websocket.server.ServerEndpoint}, POJOs that are annotated with this
  * annotation can have methods that, using the web socket method level annotations, are web socket lifecycle methods.
  * <p>
  * For example:

--- a/api/client/src/main/java/javax/websocket/Endpoint.java
+++ b/api/client/src/main/java/javax/websocket/Endpoint.java
@@ -31,14 +31,14 @@ package javax.websocket;
  *
  * <p>
  * When deployed as a server endpoint, the implementation uses the
- * {@link javax.websocket.server.ServerEndpointConfig.Configurator#getEndpointInstance} method to obtain the endpoint
+ * {@code javax.websocket.server.ServerEndpointConfig.Configurator#getEndpointInstance} method to obtain the endpoint
  * instance it will use for each new client connection. If the developer uses the default
- * {@link javax.websocket.server.ServerEndpointConfig.Configurator}, there will be precisely one endpoint instance per
+ * {@code javax.websocket.server.ServerEndpointConfig.Configurator}, there will be precisely one endpoint instance per
  * active client connection. Consequently, in this typical case, when implementing/overriding the methods of Endpoint,
  * the developer is guaranteed that there will be at most one thread calling each endpoint instance at a time.
  *
  * <p>
- * If the developer provides a custom {@link javax.websocket.server.ServerEndpointConfig.Configurator} which overrides
+ * If the developer provides a custom {@code javax.websocket.server.ServerEndpointConfig.Configurator} which overrides
  * the default policy for endpoint instance creation, for example, using a single Endpoint instance for multiple client
  * connections, the developer may need to write code that can execute concurrently.
  *

--- a/api/client/src/main/java/javax/websocket/OnClose.java
+++ b/api/client/src/main/java/javax/websocket/OnClose.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * <ul>
  * <li>optional {@link Session} parameter</li>
  * <li>optional {@link CloseReason} parameter</li>
- * <li>Zero to n String parameters annotated with the {@link javax.websocket.server.PathParam} annotation.</li>
+ * <li>Zero to n String parameters annotated with the {@code javax.websocket.server.PathParam} annotation.</li>
  * </ul>
  *
  * <p>

--- a/api/client/src/main/java/javax/websocket/OnError.java
+++ b/api/client/src/main/java/javax/websocket/OnError.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * <ul>
  * <li>optional {@link Session} parameter</li>
  * <li>a {@link java.lang.Throwable} parameter</li>
- * <li>Zero to n String parameters annotated with the {@link javax.websocket.server.PathParam} annotation</li>
+ * <li>Zero to n String parameters annotated with the {@code javax.websocket.server.PathParam} annotation</li>
  * </ul>
  *
  * <p>

--- a/api/client/src/main/java/javax/websocket/OnMessage.java
+++ b/api/client/src/main/java/javax/websocket/OnMessage.java
@@ -58,7 +58,7 @@ import java.lang.annotation.Target;
  * </li>
  * </ul>
  * </li>
- * <li>and Zero to n String or Java primitive parameters annotated with the {@link javax.websocket.server.PathParam}
+ * <li>and Zero to n String or Java primitive parameters annotated with the {@code javax.websocket.server.PathParam}
  * annotation for server endpoints.</li>
  * <li>and an optional {@link Session} parameter</li>
  * </ol>

--- a/api/client/src/main/java/javax/websocket/OnOpen.java
+++ b/api/client/src/main/java/javax/websocket/OnOpen.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * <ul>
  * <li>optional {@link Session} parameter</li>
  * <li>optional {@link EndpointConfig} parameter</li>
- * <li>Zero to n String parameters annotated with the {@link javax.websocket.server.PathParam} annotation.</li>
+ * <li>Zero to n String parameters annotated with the {@code javax.websocket.server.PathParam} annotation.</li>
  * </ul>
  *
  * <p>

--- a/api/client/src/main/java/javax/websocket/WebSocketContainer.java
+++ b/api/client/src/main/java/javax/websocket/WebSocketContainer.java
@@ -58,7 +58,7 @@ public interface WebSocketContainer {
 
     /**
      * Connect the supplied annotated endpoint instance to its server. The supplied object must be a class decorated
-     * with the class level {@link javax.websocket.server.ServerEndpoint} annotation. This method blocks until the
+     * with the class level {@code javax.websocket.server.ServerEndpoint} annotation. This method blocks until the
      * connection is established, or throws an error if either the connection could not be made or there was a problem
      * with the supplied endpoint class. If the developer uses this method to deploy the client endpoint, services like
      * dependency injection that are supported, for example, when the implementation is part of the Java EE platform may
@@ -77,7 +77,7 @@ public interface WebSocketContainer {
 
     /**
      * Connect the supplied annotated endpoint to its server. The supplied object must be a class decorated with the
-     * class level {@link javax.websocket.server.ServerEndpoint} annotation. This method blocks until the connection is
+     * class level {@code javax.websocket.server.ServerEndpoint} annotation. This method blocks until the connection is
      * established, or throws an error if either the connection could not be made or there was a problem with the
      * supplied endpoint class.
      *


### PR DESCRIPTION
The server API depends on the client API. Therefore the client API
Javadoc may not reference (via {@link ...}) the server API Javadoc as
that creates a circular reference. Therefore, replace all {@link ...}
references to the server API in the client API with {@code ...}

Signed-off-by: Mark Thomas <markt@apache.org>