### PR TITLE
Ensuring that LICENSE/NOTICE shows up in META-INF

### DIFF
--- a/api/client/pom.xml
+++ b/api/client/pom.xml
@@ -32,4 +32,17 @@
     <description>JSR 356: Java API for WebSocket</description>
     <url>https://projects.eclipse.org/projects/ee4j.websocket</url>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/../../</directory>
+                <includes>
+                    <include>LICENSE.md</include>
+                    <include>NOTICE.md</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
+    </build>
+
 </project>

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -33,6 +33,16 @@
     <url>https://projects.eclipse.org/projects/ee4j.websocket</url>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/../../</directory>
+                <includes>
+                    <include>LICENSE.md</include>
+                    <include>NOTICE.md</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
         <plugins>
             <!--
                 Commented out as this plug-in currently breaks the build due to


### PR DESCRIPTION
This PR makes the `LICENSE.md` and `NOTICE.md` files show up in the `META-INF` directory of the two artifacts we produce.
