### PR TITLE
Ensuring client-api is a Bundle too.

### DIFF
--- a/api/client/pom.xml
+++ b/api/client/pom.xml
@@ -27,9 +27,40 @@
     </parent>
 
     <artifactId>jakarta.websocket-client-api</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>WebSocket client API</name>
     <description>JSR 356: Java API for WebSocket</description>
     <url>https://projects.eclipse.org/projects/ee4j.websocket</url>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>spec-version-maven-plugin</artifactId>
+                <configuration>
+                    <specMode>jakarta</specMode>
+                    <spec>
+                        <nonFinal>false</nonFinal>
+                        <jarType>api</jarType>
+                        <apiPackage>${api_package}.client</apiPackage>
+                        <specVersion>${spec_version}</specVersion>
+                        <specImplVersion>${spec_impl_version}</specImplVersion>
+                    </spec>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>set-spec-properties</goal>
+                            <goal>check-module</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -197,6 +197,57 @@
         </plugins>
         <pluginManagement>
             <plugins>
+                <!--
+                    Commented out as this plug-in currently breaks the build due to
+                    a hard-coded requirement that the groupId starts with javax.
+                    See #266
+                -->
+                <plugin>
+                    <groupId>org.glassfish.build</groupId>
+                    <artifactId>spec-version-maven-plugin</artifactId>
+                    <configuration>
+                        <specMode>jakarta</specMode>
+                        <spec>
+                            <nonFinal>false</nonFinal>
+                            <jarType>api</jarType>
+                            <specVersion>${spec_version}</specVersion>
+                            <!--<newSpecVersion>${new_spec_version}</newSpecVersion>-->
+                            <specImplVersion>${spec_impl_version}</specImplVersion>
+                            <apiPackage>${api_package}</apiPackage>
+                            <!--<specBuild>${spec_build}</specBuild>-->
+                        </spec>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>set-spec-properties</goal>
+                                <goal>check-module</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <!--
+                  This plugin is responsible for packaging artifacts
+                  as OSGi bundles.  Please refer to
+                  http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html
+                  for more information about how to use this plugin.
+                -->
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>2.3.7</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <instructions>
+                            <Bundle-Version>${spec.bundle.version}</Bundle-Version>
+                            <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
+                            <Extension-Name>${spec.extension.name}</Extension-Name>
+                            <Implementation-Version>${spec.implementation.version}</Implementation-Version>
+                            <Specification-Version>${spec.specification.version}</Specification-Version>
+                            <Export-Package>${packages.export}</Export-Package>
+                        </instructions>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -34,11 +34,6 @@
 
     <build>
         <plugins>
-            <!--
-                Commented out as this plug-in currently breaks the build due to
-                a hard-coded requirement that the groupId starts with javax.
-                See #266
-            -->
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
@@ -47,11 +42,9 @@
                     <spec>
                         <nonFinal>false</nonFinal>
                         <jarType>api</jarType>
-                        <specVersion>${spec_version}</specVersion>
-                        <!--<newSpecVersion>${new_spec_version}</newSpecVersion>-->
-                        <specImplVersion>${spec_impl_version}</specImplVersion>
                         <apiPackage>${api_package}</apiPackage>
-                        <!--<specBuild>${spec_build}</specBuild>-->
+                        <specVersion>${spec_version}</specVersion>
+                        <specImplVersion>${spec_impl_version}</specImplVersion>
                     </spec>
                 </configuration>
                 <executions>
@@ -63,27 +56,10 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--
-              This plugin is responsible for packaging artifacts
-              as OSGi bundles.  Please refer to
-              http://felix.apache.org/site/apache-felix-maven-bundle-plugin-bnd.html
-              for more information about how to use this plugin.
-            -->
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
                 <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                        <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
-                        <Extension-Name>${spec.extension.name}</Extension-Name>
-                        <Implementation-Version>${spec.implementation.version}</Implementation-Version>
-                        <Specification-Version>${spec.specification.version}</Specification-Version>
-                        <Export-Package>${packages.export}</Export-Package>
-                    </instructions>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
+ Refactoring spec-version and bundle plugins to parent pom.
+ Ensuring client symbolic-name is unique to existing
  server symbolic-name, and that there's no dependency
  declared between them (in an OSGi sense)

Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>