### PR TITLE
Issue #206 - Fix incorrect javadoc for WebSocketContainer connectToServer.

### DIFF
--- a/api/client/src/main/java/jakarta/websocket/WebSocketContainer.java
+++ b/api/client/src/main/java/jakarta/websocket/WebSocketContainer.java
@@ -58,7 +58,7 @@ public interface WebSocketContainer {
 
     /**
      * Connect the supplied annotated endpoint instance to its server. The supplied object must be a class decorated
-     * with the class level {@code jakarta.websocket.server.ServerEndpoint} annotation. This method blocks until the
+     * with the class level {@link jakarta.websocket.ClientEndpoint} annotation. This method blocks until the
      * connection is established, or throws an error if either the connection could not be made or there was a problem
      * with the supplied endpoint class. If the developer uses this method to deploy the client endpoint, services like
      * dependency injection that are supported, for example, when the implementation is part of the Java EE platform may
@@ -77,7 +77,7 @@ public interface WebSocketContainer {
 
     /**
      * Connect the supplied annotated endpoint to its server. The supplied object must be a class decorated with the
-     * class level {@code jakarta.websocket.server.ServerEndpoint} annotation. This method blocks until the connection is
+     * class level {@link jakarta.websocket.ClientEndpoint} annotation. This method blocks until the connection is
      * established, or throws an error if either the connection could not be made or there was a problem with the
      * supplied endpoint class.
      *


### PR DESCRIPTION
**Issue #206**

This was half fixed in PR #256 but was later reverted in a formatting clean up (3b3146d1a0e7017231625b83bf30d22b7c4272e7).
