### PR TITLE
Updates to build with latest java

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -172,7 +172,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <docfilessubdirs>true</docfilessubdirs>
                     <groups>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -120,8 +120,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/spec/src/main/asciidoc/WebSocket.adoc
+++ b/spec/src/main/asciidoc/WebSocket.adoc
@@ -6,10 +6,10 @@ All rights reserved.
 
 Eclipse is a registered trademark of the Eclipse Foundation. Jakarta
 is a trademark of the Eclipse Foundation. Oracle and Java are
-registered trademarks of Oracle and/or its  affiliates. Other names
+registered trademarks of Oracle and/or its affiliates. Other names
 may be trademarks of their respective owners. 
 
-The Jakarta WebSocket Community TBD, 2020
+The Jakarta WebSocket Team TBD, 2020
 
 Comments to: websocket-dev@eclipse.org
 


### PR DESCRIPTION
Having updated the CI system to build with all available JDK-8, JDK-11 and JDK-latest we are getting failures on the JDK-latest builds.

This PR fixes those issues (and also includes a couple a typo fixes for the spec doc)

The main concern with this PR is that updates the source and target version from 1.6 to 8. While the code will compile with Java 6 I thnk it is time to update these so we/users can build with newer versions of Java.