### PR TITLE
Fix CI failures with latest JDKs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -193,7 +193,7 @@
                         Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.
                     ]]></bottom>
                     <includeDependencySources>true</includeDependencySources>
-                    <failOnError>false</failOnError>
+                    <source>8</source>
                 </configuration>
 
                 <executions>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>


### PR DESCRIPTION
Despite the builds running locally, CI continued to fail. I'm not sure why. Versions used were the same as far as I could tell.

Updating the Maven enforcer plug-in fixed the CI builds with the various latest JDKs. I ran the CI against the same branch this PR is generated from to make sure.