### PR TITLE
Fix #195 - explicitly state /a/{var} does not match /a/b/

### DIFF
--- a/spec/src/main/asciidoc/WebSocket.adoc
+++ b/spec/src/main/asciidoc/WebSocket.adoc
@@ -510,6 +510,7 @@ matches this is /a/b/
 with reserved characters "/" are not valid URI-template level 1
 expansions):
 ** /a
+** /a/b/
 ** /a/b/c
 
 


### PR DESCRIPTION
Looking at the Tomcat unit tests I see there is an explicit test that
/a/{var} does not match /a/b/ as a result of EG discussion.