### PR TITLE
Fix content of source JAR

### DIFF
--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -71,7 +71,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>attach-source-jar</id>
+                        <id>attach-sources</id>
                         <goals>
                             <goal>jar</goal>
                         </goals>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -105,7 +105,7 @@
                 <version>3.0.0-M3</version>
                 <executions>
                     <execution>
-                        <id>enforce</id>
+                        <id>enforce-maven</id>
                         <goals>
                             <goal>enforce</goal>
                         </goals>


### PR DESCRIPTION
Override parent rather than add to
Fixes an issue where the source JAR build by CI misses some classes. Not observed on local build - possibly due to different maven command to CI deploy job.

Signed-off-by: Mark Thomas <markt@apache.org>