### PR TITLE
Disable source JAR config from EE4J parent

### DIFF
--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -82,6 +82,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Disable source JAR from EE4j parent as we create the source JAR above -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
This POM has a custom source JAR config so disabling the one from the
EE4J parent prevents the possibility of the wrong source JAR
over-writing the correct one (plug-in execution order can vary).

Signed-off-by: Mark Thomas <markt@apache.org>