### PR TITLE
357: Remove the automatic module names (for 2.0.0 branch)

### DIFF
--- a/api/client/pom.xml
+++ b/api/client/pom.xml
@@ -33,7 +33,7 @@
     <url>https://projects.eclipse.org/projects/ee4j.websocket</url>
 
     <properties>
-        <jpms.name>jakarta.websocket.client.api</jpms.name>
+        <jpms.name>jakarta.websocket.client</jpms.name>
     </properties>
 
     <build>
@@ -74,7 +74,7 @@
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                         <manifestEntries>
-                            <Automatic-Module-Name>jakarta.websocket.client.api</Automatic-Module-Name>
+                            <Automatic-Module-Name>jakarta.websocket.client</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/api/server/pom.xml
+++ b/api/server/pom.xml
@@ -33,7 +33,7 @@
     <url>https://projects.eclipse.org/projects/ee4j.websocket</url>
 
     <properties>
-        <jpms.name>jakarta.websocket.api</jpms.name>
+        <jpms.name>jakarta.websocket</jpms.name>
     </properties>
 
     <build>


### PR DESCRIPTION
Task-Url: https://github.com/eclipse-ee4j/websocket-api/issues/357

Signed-off-by: Werner Keil <werner.keil@gmx.net>