### PR TITLE
Fix #190 and #192. Clarify messages and MessageHandler add/remove

### DIFF
--- a/api/client/src/main/java/jakarta/websocket/Session.java
+++ b/api/client/src/main/java/jakarta/websocket/Session.java
@@ -65,6 +65,9 @@ public interface Session extends Closeable {
      * cases (Lambda Expressions, more complex inheritance or generic type arrangements), one of the following methods
      * have to be used: {@link #addMessageHandler(Class, jakarta.websocket.MessageHandler.Whole)} or
      * {@link #addMessageHandler(Class, jakarta.websocket.MessageHandler.Partial)}.
+     * <p>
+     * Once the container has identified a MessageHandler for a message, the MessageHandler is used for the entirety of
+     * the message irrespective of any subsequent changes to the MessageHandlers configured for the Session.
      *
      * @param handler the MessageHandler to be added.
      * @throws IllegalStateException if there is already a MessageHandler registered for the same native websocket
@@ -79,6 +82,9 @@ public interface Session extends Closeable {
      * maximum of one for handling incoming pong messages. For further details of which message handlers handle which of
      * the native websocket message types please see {@link MessageHandler.Whole} and {@link MessageHandler.Partial}.
      * Adding more than one of any one type will result in a runtime exception.
+     * <p>
+     * Once the container has identified a MessageHandler for a message, the MessageHandler is used for the entirety of
+     * the message irrespective of any subsequent changes to the MessageHandlers configured for the Session.
      *
      * @param <T>     type of message that the given handler is intended for.
      * @param clazz   type of the message processed by message handler to be registered.
@@ -96,6 +102,9 @@ public interface Session extends Closeable {
      * maximum of one for handling incoming pong messages. For further details of which message handlers handle which of
      * the native websocket message types please see {@link MessageHandler.Whole} and {@link MessageHandler.Partial}.
      * Adding more than one of any one type will result in a runtime exception.
+     * <p>
+     * Once the container has identified a MessageHandler for a message, the MessageHandler is used for the entirety of
+     * the message irrespective of any subsequent changes to the MessageHandlers configured for the Session.
      *
      * @param <T>     type of message that the given handler is intended for.
      * @param clazz   type of the message processed by message handler to be registered.
@@ -116,6 +125,9 @@ public interface Session extends Closeable {
     /**
      * Remove the given MessageHandler from the set belonging to this session. This method may block if the given
      * handler is processing a message until it is no longer in use.
+     * <p>
+     * Once the container has identified a MessageHandler for a message, the MessageHandler is used for the entirety of
+     * the message irrespective of any subsequent changes to the MessageHandlers configured for the Session.
      *
      * @param handler the handler to be removed.
      */

--- a/spec/src/main/asciidoc/WebSocket.adoc
+++ b/spec/src/main/asciidoc/WebSocket.adoc
@@ -1,8 +1,8 @@
 :xrefstyle: short
 :sectnums!:
-== Jakarta WebSocket Specification, Version 2.0
+== Jakarta WebSocket Specification, Version 2.1
 
-Copyright (c) 2011, 2020 Oracle and/or its affiliates and others.
+Copyright (c) 2011, 2021 Oracle and/or its affiliates and others.
 All rights reserved.
 
 Eclipse is a registered trademark of the Eclipse Foundation. Jakarta
@@ -223,6 +223,12 @@ messages. The WebSocket implementation must generate an error if this
 restriction is violated [WSC 2.1.3-2].
 
 Future versions of the specification may lift this restriction.
+
+The registered *MessageHandlers* for a *Session* may be changed at runtime.
+To avoid any ambiguity, once the container has identified a *MessageHandler*
+for a message, the *MessageHandler* is used for the entirety of the message
+irrespective of any subsequent changes to the *MessageHandlers* configured
+for the *Session*.
 
 Method *Session.addMessageHandler(MessageHandler)* is not safe for use
 in all circumstances, especially when using Lambda Expressions. The API


### PR DESCRIPTION
To quote gregw "Once you start a websocket message, you continue to use
the same MessageHandler for the entire message."