### PR TITLE
Fix #210 - Add an API for client-side TLS configuration

### DIFF
--- a/api/client/src/main/java/jakarta/websocket/ClientEndpointConfig.java
+++ b/api/client/src/main/java/jakarta/websocket/ClientEndpointConfig.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import javax.net.ssl.SSLContext;
+
 /**
  * The ClientEndpointConfig is a special kind of endpoint configuration object that contains web socket configuration
  * information specific only to client endpoints. Developers deploying programmatic client endpoints can create
@@ -54,12 +56,21 @@ public interface ClientEndpointConfig extends EndpointConfig {
     List<Extension> getExtensions();
 
     /**
+     * Return the SSLContext to be used to establish a WebSocket (wss) connection to the server. The SSLContext will
+     * have initialised. For insecure WebSocket (ws) connections, this will be {@code null}.
+     *
+     * @return the SSLContext to use to establish a secure connection to the server or {@code null} if an insecure
+     *         connection should be established
+     */
+    SSLContext getSSLContext();
+
+    /**
      * Return the custom configurator for this configuration. If the developer did not provide one, the platform default
      * configurator is returned.
      *
      * @return the configurator in use with this configuration.
      */
-    public ClientEndpointConfig.Configurator getConfigurator();
+    ClientEndpointConfig.Configurator getConfigurator();
 
     /**
      * The Configurator class may be extended by developers who want to provide custom configuration algorithms, such as
@@ -120,6 +131,7 @@ public interface ClientEndpointConfig extends EndpointConfig {
         private List<Extension> extensions = Collections.emptyList();
         private List<Class<? extends Encoder>> encoders = Collections.emptyList();
         private List<Class<? extends Decoder>> decoders = Collections.emptyList();
+        private SSLContext sslContext = null;
         private ClientEndpointConfig.Configurator clientEndpointConfigurator = new ClientEndpointConfig.Configurator() {
 
         };
@@ -145,7 +157,7 @@ public interface ClientEndpointConfig extends EndpointConfig {
          */
         public ClientEndpointConfig build() {
             return new DefaultClientEndpointConfig(this.preferredSubprotocols, this.extensions, this.encoders,
-                    this.decoders, this.clientEndpointConfigurator);
+                    this.decoders, this.sslContext, this.clientEndpointConfigurator);
         }
 
         /**
@@ -206,6 +218,9 @@ public interface ClientEndpointConfig extends EndpointConfig {
             return this;
         }
 
+        public ClientEndpointConfig.Builder sslContext(SSLContext sslContext) {
+            this.sslContext = sslContext;
+            return this;
+        }
     }
-
 }

--- a/api/client/src/main/java/jakarta/websocket/DefaultClientEndpointConfig.java
+++ b/api/client/src/main/java/jakarta/websocket/DefaultClientEndpointConfig.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.net.ssl.SSLContext;
+
 /**
  * The DefaultClientEndpointConfig is a concrete implementation of a client configuration.
  *
@@ -33,15 +35,17 @@ final class DefaultClientEndpointConfig implements ClientEndpointConfig {
     private List<Class<? extends Encoder>> encoders;
     private List<Class<? extends Decoder>> decoders;
     private Map<String, Object> userProperties = new HashMap<>();
+    private SSLContext sslContext;
     private ClientEndpointConfig.Configurator clientEndpointConfigurator;
 
     DefaultClientEndpointConfig(List<String> preferredSubprotocols, List<Extension> extensions,
             List<Class<? extends Encoder>> encoders, List<Class<? extends Decoder>> decoders,
-            ClientEndpointConfig.Configurator clientEndpointConfigurator) {
+            SSLContext sslContext, ClientEndpointConfig.Configurator clientEndpointConfigurator) {
         this.preferredSubprotocols = Collections.unmodifiableList(preferredSubprotocols);
         this.extensions = Collections.unmodifiableList(extensions);
         this.encoders = Collections.unmodifiableList(encoders);
         this.decoders = Collections.unmodifiableList(decoders);
+        this.sslContext = sslContext;
         this.clientEndpointConfigurator = clientEndpointConfigurator;
     }
 
@@ -93,6 +97,14 @@ final class DefaultClientEndpointConfig implements ClientEndpointConfig {
     @Override
     public final Map<String, Object> getUserProperties() {
         return this.userProperties;
+    }
+
+    /**
+     * SSLContext to use foe secure WebSocket (wss) connections.
+     */
+    @Override
+    public SSLContext getSSLContext() {
+        return this.sslContext;
     }
 
     @Override

--- a/spec/src/main/asciidoc/WebSocket.adoc
+++ b/spec/src/main/asciidoc/WebSocket.adoc
@@ -655,6 +655,13 @@ extensions to send, in order of preference, the extensions, including
 parameters, that it would like to use in the opening handshake it
 formulates [WSC-3.2.2-1].
 
+[[sslcontext]]
+==== SSLContext
+
+The default client configuration uses the developer provided SSLContext to
+establish a secure WebSocket connection if the connection uses the wss
+protocol.
+
 [[client-configuration-modification]]
 ==== Client Configuration Modification
 
@@ -1473,6 +1480,12 @@ either to the *GOLD_MEMBER* or *PLATINUM_MEMBER* roles.
 
 This appendix lists the changes in the WebSocket specification.
 This appendix is non-normative.
+
+[[changes-since=2.0]]
+
+* https://github.com/eclipse-ee4j/websocket-api/issues/210[Issue 210]
+Introduce an API to allow client side configuration of TLS (wss) connections
+to a WebSocket server.
 
 [[changes-since-jsr-356]]
 === Changes Between 2.0 and JSR-356


### PR DESCRIPTION
I've implemented the same API changes in Tomcat and updated the Tomcat unit tests to use the new API and the WebSocket/TLS tests still pass. 