### PR TITLE
Fix #517 - Clarify RemoteEndpoint.Async.setSendTimeout(long)

### DIFF
--- a/api/client/src/main/java/jakarta/websocket/RemoteEndpoint.java
+++ b/api/client/src/main/java/jakarta/websocket/RemoteEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates and others.
+ * Copyright (c) 2018, 2025 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -142,7 +142,9 @@ public interface RemoteEndpoint {
         /**
          * Sets the number of milliseconds the implementation will timeout attempting to send a websocket message. A
          * zero or negative value indicates the implementation will not timeout attempting to send a websocket message
-         * asynchronously. This value overrides the default value assigned in the WebSocketContainer.
+         * asynchronously. This value overrides the default value assigned in the WebSocketContainer. This timeout 
+         * applies per message to sends initiated after this call completes.  If batching is enabled, the timeout 
+         * applies once the messages are flushed. The default is -1.
          *
          * @param timeoutmillis The number of milliseconds this RemoteEndpoint will wait before timing out an incomplete
          *                      asynchronous message send.

--- a/spec/src/main/asciidoc/WebSocket.adoc
+++ b/spec/src/main/asciidoc/WebSocket.adoc
@@ -1533,6 +1533,9 @@ if present, is available during the WebSocket handshake.
 Clarify that `ClientEndPoint.Configurator.afterResponse(HandshakeResponse)` is to be called after both successful and
 unsuccessful WebSocket handshakes.
 
+* https://github.com/jakartaee/websocket/issues/517[Issue 517]
+Clarify that `RemoteEndpoint.Async.setSendTimeout(long)` applies per websocket message
+
 === Changes Between 2.2 and 2.1
 
 * https://github.com/jakartaee/websocket/issues/176[Issue 176]


### PR DESCRIPTION
Proposal for #517

It looks like Tomcat (11), Liberty (25.0.0.x), and Jetty (12.1) use a timeout per write, so it should be a no-op on the implementation side. 

Thanks!