### PR TITLE
Remove userProperties size checks for TCK Challenge 475

### DIFF
--- a/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/UserPropertiesConfigurator.java
+++ b/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/UserPropertiesConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,12 +31,6 @@ public class UserPropertiesConfigurator extends Configurator {
 	@Override
 	public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response) {
 		Map<String, Object> userProperties = sec.getUserProperties();
-
-		// First check that the expected properties are present
-		if (userProperties.size() != 2) {
-			throw new IllegalStateException(
-					"User properties map has [" + userProperties.size() + "] entries when 2 are expected");
-		}
 
 		// Then check that both expected keys are present
 		checkKey(userProperties, UserPropertiesServerEndpointConfig.KEY_1);

--- a/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/WSProgramaticUserPropertiesServer.java
+++ b/tck/spec-tests/src/main/java/com/sun/ts/tests/websocket/ee/jakarta/websocket/server/serverendpointconfig/WSProgramaticUserPropertiesServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,12 +33,6 @@ public class WSProgramaticUserPropertiesServer extends Endpoint implements Messa
 	@Override
 	public void onMessage(String msg) {
 		Map<String, Object> userProperties = session.getUserProperties();
-
-		// First check that the expected properties are present
-		if (userProperties.size() != 3) {
-			throw new IllegalStateException(
-					"User properties map has [" + userProperties.size() + "] entries when 3 are expected");
-		}
 
 		// Then check expected keys are present
 		checkKey(userProperties, UserPropertiesServerEndpointConfig.KEY_1);


### PR DESCRIPTION
for #475

My understanding is that these checks failed for Jetty because it included additional properties.  By removing the two size checks, and only verifying the properties added by the TCK test app, it should pass for implementations that choose to add extra properties. 

If approved, I can also back-port this change.

Thanks.